### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/seita1996/hitori/security/code-scanning/3](https://github.com/seita1996/hitori/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the steps in the workflow, it only needs to read the repository contents (`contents: read`). No write permissions are required, as the workflow does not modify repository contents or perform other write operations.

The `permissions` block will be added at the top level of the workflow, applying to all jobs (`build` and `backend-test`) unless overridden by job-specific `permissions` blocks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
